### PR TITLE
Error management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,8 +103,11 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "defmt",
+ "derive_more",
  "embedded-hal",
  "embedded-sdmmc",
+ "heapless",
+ "postcard",
 ]
 
 [[package]]
@@ -420,6 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
 dependencies = [
  "cobs",
+ "defmt",
  "heapless",
  "serde",
 ]
@@ -565,18 +569,18 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ members = [
 version = "0.15.1"
 features = ["same51j", "same51j-rt"]
 
+[workspace.dependencies.serde]
+version = "1.0.150"
+default-features = false
+features = ["derive"]
+
+[workspace.dependencies.cortex-m]
+version = "0.7.6"
+features = ["critical-section-single-core"]
+
 [profile.dev]
 # Using LTO causes issues with GDB
 lto = false

--- a/boards/main/Cargo.toml
+++ b/boards/main/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = { version = "^0.7.0", features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
 cortex-m-rt = "^0.7.0"
 cortex-m-rtic = "1.1.3"
 panic-halt = "0.2.0"

--- a/libraries/common-arm/Cargo.toml
+++ b/libraries/common-arm/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cortex-m = { workspace = true }
+postcard = { version = "1.0.2", features = ["use-defmt"] }
 defmt = "0.3.2"
+heapless = "0.7.16"
+derive_more = "0.99.17"
 atsamd-hal = { workspace = true }
-cortex-m = { version = "^0.7.0", features = ["critical-section-single-core"] }
 cortex-m-rt = "^0.7.0"
 embedded-sdmmc = "0.3.0"
 embedded-hal = "0.2.7"

--- a/libraries/common-arm/src/error/error_manager.rs
+++ b/libraries/common-arm/src/error/error_manager.rs
@@ -1,0 +1,56 @@
+use crate::error::hydra_error::HydraError;
+use core::cell::RefCell;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering::Relaxed;
+use cortex_m::interrupt;
+use cortex_m::interrupt::Mutex;
+use defmt::error;
+use heapless::HistoryBuffer;
+
+/// Central error management for HYDRA. A single instance of this should be created for each board.
+pub struct ErrorManager {
+    has_error: AtomicBool,
+    error_history: Mutex<RefCell<HistoryBuffer<HydraError, 8>>>,
+}
+
+impl Default for ErrorManager {
+    fn default() -> Self {
+        ErrorManager::new()
+    }
+}
+
+impl ErrorManager {
+    pub fn new() -> Self {
+        ErrorManager {
+            has_error: false.into(),
+            error_history: Mutex::new(RefCell::new(HistoryBuffer::new())),
+        }
+    }
+
+    /// Runs the given closure. [`ErrorManager::handle()`] will be called on the closure's result.
+    pub fn run<F>(&self, callback: F)
+    where
+        F: FnOnce() -> Result<(), HydraError>,
+    {
+        let result = callback();
+        self.handle(result);
+    }
+
+    /// Handles any possible errors. This will store the error and log it using defmt.
+    pub fn handle(&self, result: Result<(), HydraError>) {
+        if let Err(e) = result {
+            self.has_error.store(true, Relaxed);
+
+            error!("{}", e);
+
+            interrupt::free(|cs| {
+                self.error_history.borrow(cs).borrow_mut().write(e);
+            });
+        }
+    }
+
+    /// Returns if any error has been raised.
+    pub fn has_error(&self) -> bool {
+        self.has_error.load(Relaxed)
+    }
+}

--- a/libraries/common-arm/src/error/hydra_error.rs
+++ b/libraries/common-arm/src/error/hydra_error.rs
@@ -1,0 +1,47 @@
+use core::convert::Infallible;
+use defmt::write;
+use derive_more::From;
+
+/// Standard HYDRA error. Add variants to this enum for any errors that can occur in the codebase.
+#[derive(From)]
+pub enum HydraError {
+    /// An Infallible error. This error should never happen.
+    Infallible(Infallible),
+    /// Error from the Postcard serialization library.
+    PostcardError(postcard::Error),
+    /// Error that occurred while spawning an RTIC task. Contains the name of the failed task.
+    SpawnError(&'static str),
+}
+
+impl defmt::Format for HydraError {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            HydraError::Infallible(_) => {
+                write!(f, "Infallible error encountered!")
+            }
+            HydraError::PostcardError(e) => {
+                write!(f, "Postcard error: {}", e)
+            }
+            HydraError::SpawnError(e) => {
+                write!(f, "Could not spawn task '{}'", e);
+            }
+        }
+    }
+}
+
+/// Utility trait for implementing an easy way to convert a RTIC spawn error to a [`HydraError`].
+/// This is necessary because RTIC doesn't have a standard error type.
+pub trait SpawnError {
+    fn spawn_error(self, task: &'static str) -> Result<(), HydraError>;
+}
+
+impl<T, E> SpawnError for Result<T, E> {
+    /// Converts an RTIC spawn error into a [`HydraError`]. While this function can be used on any
+    /// `Result`, this should only be called on a `Result` from a `spawn` or `spawn_after` operation.
+    fn spawn_error(self, task: &'static str) -> Result<(), HydraError> {
+        match self {
+            Ok(_) => Ok(()),
+            Err(_) => Err(HydraError::SpawnError(task)),
+        }
+    }
+}

--- a/libraries/common-arm/src/error/mod.rs
+++ b/libraries/common-arm/src/error/mod.rs
@@ -1,0 +1,113 @@
+//! # HYDRA Error Management
+//! Using errors in a non-std environment can be non-trivial. This module contains various
+//! structs and macros to simplify and standardize error management in HYDRA.
+//!
+//! ## HydraError
+//! [`HydraError`] is the standard error type to be used throughout the HYDRA codebase. It is an enum
+//! that wraps all possible error types that can be encountered. This allows functions to have a
+//! standard `Result<_, HydraError` that can be returned. The `From` trait is also automatically
+//! implemented for all error variants, allowing the use of the `?` operator. For example:
+//! ```ignore
+//! fn send_message() -> Result<(), HydraError> {
+//!     let payload: Vec<u8, 64> = to_vec_cobs(&m)?;
+//!
+//!     for x in payload {
+//!         // Note that this error is different from the error type above
+//!         block!(uart.write(x))?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## ErrorManager
+//! While [`HydraError`] standardizes the error type, something must be done when an error happens.
+//! The [`ErrorManager`] struct provides central management for all errors. A single instance should
+//! be created in an application, and all errors should be sent to it. It will then handle those
+//! errors as needed, and store them for possible debugging.
+//!
+//! There are two mains ways to call the error manager. For simple and short code, a closure can
+//! be passed directly to it:
+//! ```
+//! # use common_arm::ErrorManager;
+//! let em = ErrorManager::new();
+//!
+//! em.run(|| {
+//!     // Do something that can throw an error
+//!     # Ok(())
+//! });
+//! ```
+//!
+//! For more complex code, it may be better to simply pass the result directly to it:
+//! ```
+//! # use common_arm::{ErrorManager, HydraError};
+//! fn foo() -> Result<(), HydraError> {
+//!     // Do something that can throw an error
+//!     # Ok(())
+//! }
+//!
+//! let em = ErrorManager::new();
+//!
+//! em.handle(foo());
+//! ```
+//!
+//! ### RTIC
+//! [`ErrorManager`] is designed to be easily used with RTIC, and uses interior mutability to handle
+//! the errors. This makes it possible to share and access an instance without using locks:
+//! ```ignore
+//! #[task(shared = [&em])]
+//! fn foo(cx: foo::Context, m: Message) {
+//!     cx.shared.em.run(|| {
+//!         // ...
+//!     });
+//! }
+//! ```
+//!
+//! ## RTIC Task Spawning
+//! Spawning software tasks in RTIC can fail for various reasons. However, the `Result` returned
+//! by spawning a task is not standard, making it challenging to transform it into a
+//! [`HydraError`] while preserving useful info like the task name that failed to spawn. The macros
+//! [`spawn`](crate::spawn!), [`spawn_after`](crate::spawn_after!), and
+//! [`spawn_all`](crate::spawn_all!) are there to facilitate handling the errors that can be returned
+//! while spawning.
+//!
+//! [`spawn`](crate::spawn!) and [`spawn_after`](crate::spawn_after!) are macros that simply spawn
+//! the given task, converting the returned `Result` into a `Result<(), HydraError>`, adding in the
+//! process some useful info to the error like the task name.
+//!
+//! Most of the time, even if a single task fails to spawn, we should still try spawning the
+//! remaining tasks. The [`spawn_all`](crate::spawn_all!) macro will try to spawn all the tasks
+//! given to it. If all tasks were spawned successfully, it will return `Ok(())`. However, if a task
+//! could not spawn, it will return it's associated error. Note that if multiple tasks could not spawn,
+//! only the last error will be returned.
+//!
+//! Together, those macros would be used like this:
+//! ```ignore
+//! spawn_all!(
+//!     spawn!(send_message, message);
+//!     spawn_after!(sensor_send, 2.secs());
+//! )?;
+//! ```
+//!
+
+pub mod error_manager;
+pub mod hydra_error;
+
+pub use error_manager::ErrorManager;
+pub use hydra_error::HydraError;
+
+/// Calls `spawn` on a RTIC's task. Transforms the returned `Result` into a `Result<_, HydraError>`.
+#[macro_export]
+macro_rules! spawn {
+    ($task:ident$(,)? $($arg:expr),*) => {
+        $crate::SpawnError::spawn_error($task::spawn($($arg),*), stringify!($task))
+    };
+}
+
+/// Calls `spawn_after` on a RTIC's task. Transforms the returned `Result` into a `Result<_, HydraError>`.
+#[macro_export]
+macro_rules! spawn_after {
+    ($task:ident$(,)? $($arg:expr),*) => {
+        $crate::SpawnError::spawn_error($task::spawn_after($($arg),*), stringify!($task))
+    };
+}

--- a/libraries/common-arm/src/lib.rs
+++ b/libraries/common-arm/src/lib.rs
@@ -1,3 +1,13 @@
 #![no_std]
-pub use crate::sd::SdInterface;
+
+//!
+//! This crate contains common code for HYDRA. Any code that is not board specific should be put in
+//! here.
+//!
+
+mod error;
 pub mod sd;
+
+pub use crate::error::error_manager::ErrorManager;
+pub use crate::error::hydra_error::SpawnError;
+pub use crate::sd::SdInterface;

--- a/libraries/messages/Cargo.toml
+++ b/libraries/messages/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99.17"
-serde = { version = "1.0.149", default-features = false, features = ["derive"] }
+serde = { workspace = true }
 defmt = "0.3.2"
 fugit = "0.3.6"


### PR DESCRIPTION
First try at error management. There are a few goals with this PR:
- Make it easy to handle errors.
- Provide as much information as possible to us when an error is raised.

For now, the error are shown using `defmt`. Maybe we'll switch to some other logging system in the future, but at least this PR gives some foundation.

Note that there are possible improvements for adding extra info to the errors. For example, which task raised this error, the exact line and file of the error, etc. However, I didn't want to go too much overboard with this right now, so we'll wait and see if this extra info is needed.