### PR TITLE
Add toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["thumbv7em-none-eabihf"]


### PR DESCRIPTION
This will tell Rust to automatically download the necessary target, no need for extra commands else than `cargo build`!

README is coming soon. Just need to figure out what we do for the docs.