### PR TITLE
State machine design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +325,7 @@ dependencies = [
  "defmt-rtt",
  "embedded-hal",
  "embedded-sdmmc",
+ "enum_dispatch",
  "panic-halt",
 ]
 
@@ -360,6 +373,12 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "panic-halt"

--- a/boards/main/Cargo.toml
+++ b/boards/main/Cargo.toml
@@ -15,3 +15,4 @@ defmt-rtt = "0.4.0"
 defmt = "0.3.2"
 atsamd-hal = { workspace = true }
 common-arm = { path = "../../libraries/common-arm" }
+enum_dispatch = "0.3.8"

--- a/boards/main/src/main.rs
+++ b/boards/main/src/main.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+mod state_machine;
+
 use atsamd_hal as hal;
 use atsamd_hal::prelude::*;
 use common_arm;
@@ -96,7 +98,9 @@ fn main() -> ! {
     micro_sd
         .write_str(&mut test_file, "Testing Strings")
         .expect("Could not write string");
-    micro_sd.close_file(test_file).expect("Could not close file."); // we are done with the file so destroy it
+    micro_sd
+        .close_file(test_file)
+        .expect("Could not close file."); // we are done with the file so destroy it
     micro_sd.close(); // we are done our test so destroy
 
     loop {

--- a/boards/main/src/state_machine/mod.rs
+++ b/boards/main/src/state_machine/mod.rs
@@ -1,0 +1,33 @@
+mod states;
+
+use crate::state_machine::states::{HydraError, RocketStates};
+use crate::state_machine::states::{Initializing, State};
+
+pub struct RocketStateMachine {
+    state: RocketStates,
+}
+
+pub struct RocketStateMachineData {
+    // Things here like sensor data, some command manager, etc.
+}
+
+impl RocketStateMachine {
+    pub fn new() -> Self {
+        let state = Initializing {};
+        state.enter();
+
+        RocketStateMachine {
+            state: state.into(),
+        }
+    }
+
+    pub fn run(&mut self, data: &RocketStateMachineData) -> Result<(), HydraError> {
+        if let Some(new_state) = self.state.step(data)? {
+            self.state.exit();
+            new_state.enter();
+            self.state = new_state;
+        }
+
+        Ok(())
+    }
+}

--- a/boards/main/src/state_machine/states.rs
+++ b/boards/main/src/state_machine/states.rs
@@ -1,0 +1,70 @@
+use crate::state_machine::RocketStateMachineData;
+use enum_dispatch::enum_dispatch;
+
+// Use the one from `common-arm` once merged
+pub struct HydraError {}
+
+#[enum_dispatch]
+pub trait State {
+    fn enter(&self) {}
+    fn exit(&self) {}
+    fn event(&mut self, _event: RocketEvents) -> Result<Option<RocketStates>, HydraError> {
+        Ok(None)
+    }
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError>;
+}
+
+pub enum RocketEvents {
+    DeployDrogue,
+    DeployMain,
+}
+
+#[enum_dispatch(State)]
+pub enum RocketStates {
+    Initializing,
+    WaitForTakeoff,
+    Cruise,
+    Coasting,
+    Falling,
+    Landed,
+}
+
+impl RocketStates {}
+
+pub struct Initializing {}
+pub struct WaitForTakeoff {}
+pub struct Cruise {}
+pub struct Coasting {}
+pub struct Falling {}
+pub struct Landed {}
+
+impl State for Initializing {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}
+impl State for WaitForTakeoff {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}
+impl State for Cruise {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}
+impl State for Coasting {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}
+impl State for Falling {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}
+impl State for Landed {
+    fn step(&mut self, data: &RocketStateMachineData) -> Result<Option<RocketStates>, HydraError> {
+        todo!()
+    }
+}


### PR DESCRIPTION
I started to experiment with the design of the state machine. For now, I think our best option is to use the `enum_dispatch` crate. Pretty much, this crate allows to do a form of dynamic dispatching using enums. This allow to have a pretty simple state machine with no dynamic allocation. This design also allows each state to hold mutable data, allowing things such as waiting for some amount of time, or remembering which commands were sent. States could also pass some data to each other when switching states.

This state machine design will probably only be used for our main state machine. We'll see, but probably will use something simpler/smaller for other potential state machines (motor control, parachute deployment, etc.)

Things left to figure out:
  - How to group states together, say if they should have a common `enter` or `exit` function. I have some ideas, but anyway this is probably not a blocker for the rocket.
  - How to implement a way for the ground station to send a command to manually enter a specific state. It will probably have something to do with each state implementing the `Default` trait. However, I don't know yet how to make it work nicely with Serde and avoiding a lot of boilerplate.

Draft PR for now. Will probably be merged only once reading from the SBG is figured out.