### PR TITLE
Fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+libraries/sbg-rs/sbgECom/** linguist-vendored


### PR DESCRIPTION
With the recent inclusion of the `sbgECom` library, Github now classifies this repo as a C library. It is outrageous that such a perfect and safe codebase be compared to the monstrosity that is C!

Anyway, add a file to tell Linguist to ignore that folder (https://github.com/github-linguist/linguist/blob/master/docs/overrides.md).