### PR TITLE
Message Improvements 

### DIFF
--- a/boards/main/src/data_manager.rs
+++ b/boards/main/src/data_manager.rs
@@ -1,15 +1,17 @@
-use messages::sensor::{Sbg, SbgShort};
+use messages::sensor::{Sbg, SbgEkf, SbgNav};
 
 pub struct DataManager {
     pub sbg: Option<Sbg>,
-    pub sbg_short: Option<SbgShort>,
+    pub sbg_nav: Option<SbgNav>,
+    pub sbg_ekf: Option<SbgEkf>,
 }
 
 impl DataManager {
     pub fn new() -> Self {
         Self {
             sbg: None,
-            sbg_short: None,
+            sbg_nav: None,
+            sbg_ekf: None,
         }
     }
 }

--- a/boards/main/src/sbg_manager.rs
+++ b/boards/main/src/sbg_manager.rs
@@ -89,10 +89,11 @@ pub fn sbg_dma(mut cx: crate::app::sbg_dma::Context) {
             };
 
             cx.shared.data_manager.lock(|data_manager| {
-                let (sbg_long_data, sbg_short_data) = sbg.sbg_device.read_data(buf);
+                let (sbg_long_data, sbg_nav_data, sbg_ekf_data) = sbg.sbg_device.read_data(buf);
 
                 data_manager.sbg = Some(sbg_long_data);
-                data_manager.sbg_short = Some(sbg_short_data);
+                data_manager.sbg_nav = Some(sbg_nav_data);
+                data_manager.sbg_ekf = Some(sbg_ekf_data);
             });
             Ok(())
         });

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -21,7 +21,7 @@ use ts_rs::TS;
 pub mod sender;
 pub mod sensor;
 
-pub const MAX_SIZE: usize = 64;
+pub const MAX_SIZE: usize = 85;
 
 /// Topmost message. Encloses all the other possible messages, and is the only thing that should
 /// be sent over the wire.

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -21,7 +21,7 @@ use ts_rs::TS;
 pub mod sender;
 pub mod sensor;
 
-pub const MAX_SIZE: usize = 85;
+pub const MAX_SIZE: usize = 64;
 
 /// Topmost message. Encloses all the other possible messages, and is the only thing that should
 /// be sent over the wire.

--- a/libraries/messages/src/sensor.rs
+++ b/libraries/messages/src/sensor.rs
@@ -17,6 +17,7 @@ pub struct Sensor {
 #[cfg_attr(feature = "ts", derive(TS))]
 #[cfg_attr(feature = "ts", ts(export))]
 pub enum SensorData {
+    Sbg(Sbg),
     SbgEkf(SbgEkf),
     SbgNav(SbgNav),
 }

--- a/libraries/messages/src/sensor.rs
+++ b/libraries/messages/src/sensor.rs
@@ -17,29 +17,48 @@ pub struct Sensor {
 #[cfg_attr(feature = "ts", derive(TS))]
 #[cfg_attr(feature = "ts", ts(export))]
 pub enum SensorData {
-    Sbg(Sbg),
-    SbgShort(SbgShort),
+    SbgEkf(SbgEkf),
+    SbgNav(SbgNav),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Format)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Format)]
 #[cfg_attr(feature = "ts", derive(TS))]
 #[cfg_attr(feature = "ts", ts(export))]
-pub struct SbgShort {
-    pub accel_y: f32,
+pub struct SbgNav {
     pub pressure: f32,
     pub height: f64,
+    pub roll: f32,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Format)]
+#[cfg_attr(feature = "ts", derive(TS))]
+#[cfg_attr(feature = "ts", ts(export))]
+pub struct SbgEkf {
+    pub accel_x: f32,
+    pub accel_y: f32,
+    pub accel_z: f32,
+    pub velocity_n: f32,
+    pub velocity_e: f32,
+    pub velocity_d: f32,
     pub quant_w: f32,
     pub quant_x: f32,
     pub quant_y: f32,
     pub quant_z: f32,
 }
 
-impl From<Sbg> for SbgShort {
+impl From<Sbg> for SbgEkf {
     fn from(sbg: Sbg) -> Self {
-        SbgShort {
+        SbgEkf {
+            accel_x: sbg.accel_x,
             accel_y: sbg.accel_y,
-            pressure: sbg.pressure,
-            height: sbg.height,
+            accel_z: sbg.accel_z,
+            velocity_n: sbg.velocity_n,
+            velocity_e: sbg.velocity_e,
+            velocity_d: sbg.velocity_d,
             quant_w: sbg.quant_w,
             quant_x: sbg.quant_x,
             quant_y: sbg.quant_y,
@@ -48,7 +67,21 @@ impl From<Sbg> for SbgShort {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Format)]
+impl From<Sbg> for SbgNav {
+    fn from(sbg: Sbg) -> Self {
+        SbgNav {
+            pressure: sbg.pressure,
+            height: sbg.height,
+            roll: sbg.roll,
+            yaw: sbg.yaw,
+            pitch: sbg.pitch,
+            latitude: sbg.latitude,
+            longitude: sbg.longitude,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Format)]
 #[cfg_attr(feature = "ts", derive(TS))]
 #[cfg_attr(feature = "ts", ts(export))]
 pub struct Sbg {

--- a/libraries/sbg-rs/src/sbg.rs
+++ b/libraries/sbg-rs/src/sbg.rs
@@ -22,7 +22,7 @@ use hal::gpio::{PA08, PA09, PB16, PB17};
 use hal::sercom::uart::Duplex;
 use hal::sercom::uart::{self, EightBit, Uart};
 use hal::sercom::{IoSet1, Sercom0, Sercom5};
-use messages::sensor::{Sbg, SbgShort};
+use messages::sensor::{Sbg, SbgNav, SbgEkf};
 type Pads = uart::PadsFromIds<Sercom0, IoSet1, PA09, PA08>;
 type PadsCDC = uart::PadsFromIds<Sercom5, IoSet1, PB17, PB16>;
 type Config = uart::Config<Pads, EightBit>;
@@ -152,7 +152,7 @@ impl SBG {
     /**
      * Reads SBG data frames for a buffer and returns the most recent data.
      */
-    pub fn read_data(&mut self, buffer: &'static [u8; SBG_BUFFER_SIZE]) -> (Sbg, SbgShort) {
+    pub fn read_data(&mut self, buffer: &'static [u8; SBG_BUFFER_SIZE]) -> (Sbg, SbgNav, SbgEkf) {
         // SAFETY: We are assigning a static mut variable.
         // Buf can only be accessed from functions called by sbgEComHandle after this assignment.
         unsafe { BUF = buffer };
@@ -169,7 +169,7 @@ impl SBG {
         // SAFETY: We are cloning a static variable.
         // This is safe because DATA cannot be modified by other tasks while SBG is locked.
         let data = unsafe { DATA.clone() }; // Probably inefficient to clone twice, but using into is more portable.
-        (data.clone(), data.into())
+        (data.clone(), data.into(), data.into())
     }
 
     /**


### PR DESCRIPTION
This PR changes the SBG data definitions to allow data to be sent over CANFD as per the requirement of payloads being under 64 bytes. This also prepares for when radio is moved to the communication board as we will no longer be able to send messages of length greater than 64 bytes. I have no better name than Sbg_Ekf for non navigation data unless others can find a better name. 