### PR TITLE
add: devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/rust:0-1-bullseye
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake
+
+# Install ARM GCC deps
+RUN mkdir -p toolchain && \
+    curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz" \
+    | tar --strip-components=1 -xJ -C toolchain
+ENV PATH="${PATH}:/toolchain/bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "DevContainer",
+	"dockerFile": "Dockerfile",
+	"features": {
+		"ghcr.io/lee-orr/rusty-dev-containers/cargo-make:0": {}
+	},
+	"remoteUser": "root"
+}


### PR DESCRIPTION
Created a [DevContainer](https://code.visualstudio.com/docs/devcontainers/containers) configuration.

![image](https://github.com/uorocketry/hydra/assets/26195439/03dfd4df-f9ba-414e-b6af-00fc918142f8)

After reopening in the DevContainer you can basically run `cargo b` without having to worry about manually installing the `arm-gcc` or `cmake` dependencies