### PR TITLE
Remove deprecated ftdi feature from probe-rs install in docker script.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake pkg-config 
 RUN mkdir -p toolchain && \
     curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz" \
     | tar --strip-components=1 -xJ -C toolchain && \
-    cargo install --locked probe-rs --features cli,ftdi
+    cargo install --locked probe-rs --features cli
 ENV PATH="${PATH}:/toolchain/bin"


### PR DESCRIPTION
Probe-rs has removed the ftdi feature flag so we must also remove it from the docker script. 