### PR TITLE
Update message size test 

### DIFF
--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -78,7 +78,7 @@ mod test {
         fn message_size(msg: Message) {
             let bytes = postcard::to_allocvec(&msg).unwrap();
 
-            dbg!(msg);
+            dbg!(&msg);
             // The size of the message should be less than or equal the maximum size.
             match msg.data {
                 crate::Data::State(_) => {

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -78,24 +78,23 @@ mod test {
         fn message_size(msg: Message) {
             let bytes = postcard::to_allocvec(&msg).unwrap();
 
-            // dbg!(msg);
-            // assert!(dbg!(bytes.len()) <= MAX_SIZE);
-            // check the messages data type is of which type and then check if the size is less than or equal there expected size
+            dbg!(msg);
+            // The size of the message should be less than or equal the maximum size.
             match msg.data {
                 crate::Data::State(_) => {
-                    assert!(bytes.len() <= 13);
+                    assert!(dbg!(bytes.len()) <= 13);
                 }
                 crate::Data::Sensor(_) => {
-                    assert!(bytes.len() <= 53);
+                    assert!(dbg!(bytes.len()) <= 53);
                 }
                 crate::Data::Log(_) => {
-                    assert!(bytes.len() <= 15);
+                    assert!(dbg!(bytes.len()) <= 15);
                 }
                 crate::Data::Command(_) => {
-                    assert!(bytes.len() <= 15);
+                    assert!(dbg!(bytes.len()) <= 15);
                 }
                 crate::Data::Health(_) => {
-                    assert!(bytes.len() <= 47);
+                    assert!(dbg!(bytes.len()) <= 47);
                 }
             }
         }

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -24,10 +24,12 @@ pub mod sensor;
 pub mod sensor_status;
 pub mod state;
 
+pub const MAX_SIZE: usize = 64;
 pub const MAX_HEALTH_SIZE: usize = 47;
 pub const MAX_SENSOR_SIZE: usize = 53;
 pub const MAX_STATE_SIZE: usize = 13;
-pub const MAX_LOGNCOMMAND_SIZE: usize = 15;
+pub const MAX_LOG_SIZE: usize = 15;
+pub const MAX_COMMAND_SIZE: usize = 15;
 
 pub use logging::{ErrorContext, Event, Log, LogLevel};
 
@@ -73,7 +75,7 @@ impl Message {
 
 #[cfg(test)]
 mod test {
-    use crate::{Message, MAX_HEALTH_SIZE, MAX_LOGNCOMMAND_SIZE, MAX_SENSOR_SIZE, MAX_STATE_SIZE};
+    use crate::{Message, MAX_HEALTH_SIZE, MAX_COMMAND_SIZE, MAX_LOG_SIZE, MAX_SENSOR_SIZE, MAX_STATE_SIZE};
     use proptest::prelude::*;
 
     proptest! {
@@ -91,10 +93,10 @@ mod test {
                     assert!(dbg!(bytes.len()) <= MAX_SENSOR_SIZE);
                 }
                 crate::Data::Log(_) => {
-                    assert!(dbg!(bytes.len()) <= MAX_LOGNCOMMAND_SIZE);
+                    assert!(dbg!(bytes.len()) <= MAX_LOG_SIZE);
                 }
                 crate::Data::Command(_) => {
-                    assert!(dbg!(bytes.len()) <= MAX_LOGNCOMMAND_SIZE);
+                    assert!(dbg!(bytes.len()) <= MAX_COMMAND_SIZE);
                 }
                 crate::Data::Health(_) => {
                     assert!(dbg!(bytes.len()) <= MAX_HEALTH_SIZE);

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -24,7 +24,10 @@ pub mod sensor;
 pub mod sensor_status;
 pub mod state;
 
-pub const MAX_SIZE: usize = 64;
+pub const MAX_HEALTH_SIZE: usize = 47;
+pub const MAX_SENSOR_SIZE: usize = 53;
+pub const MAX_STATE_SIZE: usize = 13;
+pub const MAX_LOGNCOMMAND_SIZE: usize = 15;
 
 pub use logging::{ErrorContext, Event, Log, LogLevel};
 
@@ -70,7 +73,7 @@ impl Message {
 
 #[cfg(test)]
 mod test {
-    use crate::Message;
+    use crate::{Message, MAX_HEALTH_SIZE, MAX_LOGNCOMMAND_SIZE, MAX_SENSOR_SIZE, MAX_STATE_SIZE};
     use proptest::prelude::*;
 
     proptest! {
@@ -82,19 +85,19 @@ mod test {
             // The size of the message should be less than or equal the maximum size.
             match msg.data {
                 crate::Data::State(_) => {
-                    assert!(dbg!(bytes.len()) <= 13);
+                    assert!(dbg!(bytes.len()) <= MAX_STATE_SIZE);
                 }
                 crate::Data::Sensor(_) => {
-                    assert!(dbg!(bytes.len()) <= 53);
+                    assert!(dbg!(bytes.len()) <= MAX_SENSOR_SIZE);
                 }
                 crate::Data::Log(_) => {
-                    assert!(dbg!(bytes.len()) <= 15);
+                    assert!(dbg!(bytes.len()) <= MAX_LOGNCOMMAND_SIZE);
                 }
                 crate::Data::Command(_) => {
-                    assert!(dbg!(bytes.len()) <= 15);
+                    assert!(dbg!(bytes.len()) <= MAX_LOGNCOMMAND_SIZE);
                 }
                 crate::Data::Health(_) => {
-                    assert!(dbg!(bytes.len()) <= 47);
+                    assert!(dbg!(bytes.len()) <= MAX_HEALTH_SIZE);
                 }
             }
         }

--- a/libraries/messages/src/lib.rs
+++ b/libraries/messages/src/lib.rs
@@ -70,7 +70,7 @@ impl Message {
 
 #[cfg(test)]
 mod test {
-    use crate::{Message, MAX_SIZE};
+    use crate::Message;
     use proptest::prelude::*;
 
     proptest! {
@@ -78,8 +78,26 @@ mod test {
         fn message_size(msg: Message) {
             let bytes = postcard::to_allocvec(&msg).unwrap();
 
-            dbg!(msg);
-            assert!(dbg!(bytes.len()) <= MAX_SIZE);
+            // dbg!(msg);
+            // assert!(dbg!(bytes.len()) <= MAX_SIZE);
+            // check the messages data type is of which type and then check if the size is less than or equal there expected size
+            match msg.data {
+                crate::Data::State(_) => {
+                    assert!(bytes.len() <= 13);
+                }
+                crate::Data::Sensor(_) => {
+                    assert!(bytes.len() <= 53);
+                }
+                crate::Data::Log(_) => {
+                    assert!(bytes.len() <= 15);
+                }
+                crate::Data::Command(_) => {
+                    assert!(bytes.len() <= 15);
+                }
+                crate::Data::Health(_) => {
+                    assert!(bytes.len() <= 47);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Updated the Mavlink dialect to have different messages based on the data type therefore updating the message size test to be based on the data type.