### PR TITLE
Update Dev container and README

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake pkg-config 
 RUN mkdir -p toolchain && \
     curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz" \
     | tar --strip-components=1 -xJ -C toolchain && \
-    cargo install --locked probe-rs --features cli \
-    cargo install --locked cargo-make
+    cargo install probe-rs --features cli \
+    cargo install cargo-make
 ENV PATH="${PATH}:/toolchain/bin"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,24 @@
+# Base image for toolchain download
+FROM mcr.microsoft.com/devcontainers/rust:latest as toolchain
+
+RUN mkdir -p /toolchain && \
+    curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz" \
+    | tar --strip-components=1 -xJ -C /toolchain
+
+# Final image
 FROM mcr.microsoft.com/devcontainers/rust:latest
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev libssl-dev
+# Copy the toolchain from the previous stage
+COPY --from=toolchain /toolchain /toolchain
 
-# Install ARM GCC deps
-RUN mkdir -p toolchain && \
-    curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz" \
-    | tar --strip-components=1 -xJ -C toolchain && \
-    cargo install probe-rs --features cli \
-    cargo install cargo-make
 ENV PATH="${PATH}:/toolchain/bin"
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Necessary system packages
+RUN apt-get update && apt-get install -y cmake pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev libssl-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Rust crates
+RUN cargo install probe-rs --features cli \
+    && cargo install cargo-make

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake pkg-config 
 RUN mkdir -p toolchain && \
     curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz" \
     | tar --strip-components=1 -xJ -C toolchain && \
-    cargo install --locked probe-rs --features cli
+    cargo install --locked probe-rs --features cli \
+    cargo install --locked cargo-make
 ENV PATH="${PATH}:/toolchain/bin"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode/.cortex-debug.registers.state.json
 /.vscode/.cortex-debug.peripherals.state.json
 /.vscode/settings.json
+/toolchain

--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@
 
 ## Getting Started
 
+> If you are in a DevContainer skip to step 5.
+
 1. Install Rust: https://www.rust-lang.org/tools/install
-2. Build: `cargo build`
-3. Install probe-run: `cargo install --git https://github.com/uorocketry/probe-run`
-    - `probe-run` currently requires a patch to flash our chip, so please use the above version while the patch is upstreamed
-4. Install cargo-make: `cargo install cargo-make`
-4. Flash: `cargo run --bin main`
-5. Run tests: `cargo make test-host` or `cargo make test-device`
+2. Install necessary build tools:
+  - cargo-make: `cargo install cargo-make`
+  - probe-rs: `cargo install probe-rs --features cli`
+3. Install the [ARM GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) (last tested with 13.2) and have it available in your PATH
+  - Arch Linux: `sudo pacman -S arm-none-eabi-gcc`
+  - Alpine/Debian/Ubuntu: <https://pkgs.org/download/gcc-arm-none-eabi>
+  - MacOS: `brew install arm-none-eabi-gcc`
+4. Build: `cargo build`
+  - In case it fails, try `cargo build --release`
+5. Run tests:
+  - In the host machine: `cargo make test-host`
+  - In the device: `cargo make test-device`
+6. Flash on hardware: `cargo run --bin main`
 
 For more detailed instructions on flashing, debugging, and more, please see [the wiki](https://avwiki.uorocketry.ca/en/Avionics/HYDRA/Software).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HYDRA &emsp; [![Build Status]][actions] [![docs-badge]][docs]
-*HYper Dynamic Rocketry Avionics*
+
+***HY**per **D**ynamic **R**ocketry **A**vionics*
 
 [Build Status]: https://github.com/uorocketry/hydra/actions/workflows/build.yml/badge.svg
 [actions]: https://github.com/uorocketry/hydra/actions?query=branch%3Amaster
@@ -14,53 +15,58 @@
 
 > If you are in a DevContainer skip to step 5.
 
-1. Install Rust: https://www.rust-lang.org/tools/install
-2. Install necessary build tools:
+- Install Rust: https://www.rust-lang.org/tools/install
+- Install necessary build tools:
   - cargo-make: `cargo install cargo-make`
   - probe-rs: `cargo install probe-rs --features cli`
-3. Install the [ARM GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) (last tested with 13.2) and have it available in your PATH
+- Install the [ARM GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) (last tested with 13.2) and have it available in your PATH
   - Arch Linux: `sudo pacman -S arm-none-eabi-gcc`
   - Alpine/Debian/Ubuntu: <https://pkgs.org/download/gcc-arm-none-eabi>
   - MacOS: `brew install arm-none-eabi-gcc`
-4. Build: `cargo build`
+- Build: `cargo build`
   - In case it fails, try `cargo build --release`
-5. Run tests:
+- Run tests:
   - In the host machine: `cargo make test-host`
   - In the device: `cargo make test-device`
-6. Flash on hardware: `cargo run --bin main`
+- Flash on hardware: `cargo run --bin main`
 
 For more detailed instructions on flashing, debugging, and more, please see [the wiki](https://avwiki.uorocketry.ca/en/Avionics/HYDRA/Software).
 
 ## Windows Users
 
 ### Setting up with Docker
-1. Install Docker: https://docs.docker.com/desktop/install/windows-install/
-2. Install VS Code: https://code.visualstudio.com/download
-3. From VS Code, install the "Dev Containers" extension
-4. press `ctrl` + `shift` + `p`, and search for `Dev Containers: Open Folder in Container`
+
+- Install [Docker](https://docs.docker.com/desktop/install/windows-install/)
+- Install [VS Code](https://code.visualstudio.com/download)
+- From VS Code, install the "Dev Containers" extension
+- press `ctrl` + `shift` + `p`, and search for `Dev Containers: Open Folder in Container`
 
 ### Setting up with WSL
-1. Enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install
-2. Install a linux distro from the Microsoft Store
-4. Install ARM GNU Toolchain: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+
+- Enable WSL: https://learn.microsoft.com/en-us/windows/wsl/install
+- Install a linux distro from the Microsoft Store
+- Install the [ARM GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
   - NOTE: You may find this in your distro's package manager, but ensure it is version 13.2.
   - Ubuntu has an outdated version in its repositories. If using Ubuntu, download it manually from the link above
-3. Follow the rest of the instructions in [Getting Started](#-getting-started)
+- Follow the rest of the instructions in [Getting Started](#-getting-started)
 
 ### Flashing
+
 After plugging in J-Link, it will likely show up as unknown.
+
 1. Install Zadig: https://zadig.akeo.ie/
 2. From Zadig, select J-Link as the device and WinUSB as the driver
 3. click Install Driver
 
 If using WSL or Docker with a WSL backend (you probably are), you need to tell Windows to share J-Link with WSL.
-1. From WSL, install linux-tools-generic
-  1. on Ubuntu: `sudo apt install linux-tools-generic`
-2. Install usbipd-win: https://github.com/dorssel/usbipd-win/releases
-3. Open command prompt/powershell with admin privileges and run `usbipd list`
-4. Make note of the entry called J-Link and run `usbipd bind --busid <busid>`
-5. Next, run `usbipd attach --wsl --busid <busid>`
-6. You can now follow the flashing instructions in [Getting Started](#-getting-started)
+
+- From WSL, install linux-tools-generic
+  - on Ubuntu: `sudo apt install linux-tools-generic`
+- Install usbipd-win: https://github.com/dorssel/usbipd-win/releases
+- Open command prompt/powershell with admin privileges and run `usbipd list`
+- Make note of the entry called J-Link and run `usbipd bind --busid <busid>`
+- Next, run `usbipd attach --wsl --busid <busid>`
+- You can now follow the flashing instructions in [Getting Started](#getting-started)
 
 ## Documentation
 
@@ -69,6 +75,7 @@ Run `cargo doc --open` to build and open the documentation. Most documentation f
 Documentation is also automatically built and deployed to https://hydra-docs.uorocketry.ca/common_arm
 
 ## Project Structure
+
 The project is structured in a way to allow reuse of the code across various boards and other projects.
 
 - `boards`: Folder containing each individual board's binary crates. Any code in those crates should only contain logic specific to the board.


### PR DESCRIPTION
Changes:
- Also install cargo-make
- Add devcontainer toolchain folder in gitignore
- Remove reference to the `uorocketry/probe-run` branch
- Miscellaneous markdownlint fixes] (sorry I kept getting yellow warnings on the README)
- Make dockerfile multi-layer (so we don't have to re-download the toolchain everytime we change other things